### PR TITLE
Use apertium-all-dev

### DIFF
--- a/.github/workflows/bilingual-build.yml
+++ b/.github/workflows/bilingual-build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: |
           wget https://apertium.projectjj.com/apt/install-nightly.sh -O - | sudo bash
-          sudo apt-get install -qfy apertium-dev apertium-lex-tools-dev cg3-dev gawk pkg-config apertium-regtest python3
+          sudo apt-get install -qfy apertium-all-dev python3
       - name: Checkout LANG1
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/monolingual-build.yml
+++ b/.github/workflows/monolingual-build.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install dependencies
         run: |
           wget https://apertium.projectjj.com/apt/install-nightly.sh -O - | sudo bash
-          sudo apt-get install -qfy apertium-dev apertium-lex-tools cg3-dev gawk pkg-config apertium-regtest
+          sudo apt-get install -qfy apertium-all-dev python3
       - name: Build
         run: |
           ./autogen.sh


### PR DESCRIPTION
Package `apertium-all-dev` provides all the existing required packages plus others (such as `apertium-anaphora`, `apertium-separable` and `apertium-recursive`) which are required by many pairs.